### PR TITLE
fix: use correct branch name in render cron workflow

### DIFF
--- a/.github/workflows/render-manifests-cron.yml
+++ b/.github/workflows/render-manifests-cron.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: master
+          ref: main
 
       - id: set-matrix
         uses: actions/github-script@v5
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: master
+          ref: main
 
       - uses: albertrdixon/helmfile-render@v0
         with:


### PR DESCRIPTION
## What

- Use main branch in render-manifests-cron workflow